### PR TITLE
Add RecursionSafeAsyncCaller: safe to use for recursive calls

### DIFF
--- a/tiny-async-core/src/it/java/eu/toolchain/async/RecursionSafeAsyncCallerIntegrationTest.java
+++ b/tiny-async-core/src/it/java/eu/toolchain/async/RecursionSafeAsyncCallerIntegrationTest.java
@@ -1,0 +1,123 @@
+package eu.toolchain.async;
+
+import com.google.common.util.concurrent.AtomicLongMap;
+import com.google.common.util.concurrent.MoreExecutors;
+import eu.toolchain.async.RecursionSafeAsyncCaller;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.lang.ThreadLocal;
+import java.lang.Thread;
+
+import com.google.common.util.concurrent.AtomicLongMap;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class RecursionSafeAsyncCallerIntegrationTest {
+
+    private AtomicLongMap<Long> recursionDepthPerThread;
+    private AtomicLongMap<Long> maxRecursionDepthPerThread;
+    AtomicLong totIterations;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setup() throws Exception {
+        recursionDepthPerThread = AtomicLongMap.create();
+        maxRecursionDepthPerThread = AtomicLongMap.create();
+        totIterations = new AtomicLong(0);
+    }
+
+
+    public void testBasicRecursionMethod(RecursionSafeAsyncCaller caller, ConcurrentLinkedQueue<Integer> testData) {
+
+        class RecursionRunnable implements Runnable {
+            RecursionSafeAsyncCaller caller;
+            ConcurrentLinkedQueue<Integer> testData;
+
+            RecursionRunnable(RecursionSafeAsyncCaller caller, ConcurrentLinkedQueue<Integer> testData) {
+                this.caller = caller;
+                this.testData = testData;
+            }
+
+            @Override
+            public void run() {
+                Long threadId = Thread.currentThread().getId();
+                Long currDepth = recursionDepthPerThread.addAndGet(threadId, 1L);
+                Long currMax = maxRecursionDepthPerThread.get(threadId);
+                if (currDepth > currMax) {
+                    maxRecursionDepthPerThread.put(threadId, currDepth);
+                }
+
+                if (testData.size() == 0)
+                    return;
+                testData.poll();
+                totIterations.incrementAndGet();
+
+                // Recursive call, via caller
+                testBasicRecursionMethod(caller, testData);
+
+                recursionDepthPerThread.addAndGet(threadId, -1L);
+            }
+        };
+
+        RecursionRunnable runnable = new RecursionRunnable(caller, testData);
+        caller.execute(runnable);
+    }
+
+    @Test
+    public void testBasic() throws Exception {
+        final long MAX_RECURSION_DEPTH = 2;
+        ExecutorService executorServiceReal = Executors.newFixedThreadPool(10);
+        AsyncCaller caller2 = mock(AsyncCaller.class);
+        RecursionSafeAsyncCaller recursionCaller =
+                new RecursionSafeAsyncCaller(executorServiceReal, caller2, MAX_RECURSION_DEPTH);
+        ConcurrentLinkedQueue<Integer>
+            testData = new ConcurrentLinkedQueue<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+
+        testBasicRecursionMethod(recursionCaller, testData);
+
+        // Wait for recursive calls in thread pool to create new work until done, or timeout.
+        // The executorServiceReal.shutdown() below is not enough since potentially some new work
+        // is still on the way in, due to recursive nature of the test.
+        long startTime = System.currentTimeMillis();
+        long maxTime = 1000;
+        while (testData.size() > 0) {
+            if (System.currentTimeMillis() - startTime > maxTime) {
+                // Timeout, test will fail in the assert below
+                break;
+            }
+            Thread.sleep(10);
+        }
+
+        executorServiceReal.shutdown();
+        executorServiceReal.awaitTermination(1000, TimeUnit.MILLISECONDS);
+
+        assert(testData.size() == 0);
+        assert(totIterations.get() == 10);
+
+        Long maxStackDepth=-1L;
+        Map<Long, Long> readOnlyMap = maxRecursionDepthPerThread.asMap();
+        for (Long key : readOnlyMap.keySet()) {
+            Long val = readOnlyMap.get(key);
+            if (val > maxStackDepth)
+                maxStackDepth = val;
+        }
+        assert(maxStackDepth != -1L);
+
+        // Checking with +1 since our initial call to testBasicRecursionMethod() above adds 1
+        assert(maxStackDepth <= MAX_RECURSION_DEPTH+1);
+    }
+}

--- a/tiny-async-core/src/main/java/eu/toolchain/async/RecursionSafeAsyncCaller.java
+++ b/tiny-async-core/src/main/java/eu/toolchain/async/RecursionSafeAsyncCaller.java
@@ -1,0 +1,118 @@
+/*
+ * An AsyncCaller implementation that will try to run the call in the current thread as much as
+ * possible, while keeping track of recursion to avoid StackOverflowException in the thread. If
+ * recursion becomes too deep, the next call is deferred to a separate thread (normal thread pool).
+ * State is kept per-thread - stack overflow will be avoided for any thread that passes this code.
+ * It is vital to choose a suitable maximum recursion depth.
+ */
+package eu.toolchain.async;
+
+import java.util.concurrent.ExecutorService;
+
+public final class RecursionSafeAsyncCaller implements AsyncCaller {
+    private final ExecutorService executorService;
+    private final AsyncCaller caller;
+    private final long maxRecursionDepth;
+
+    private class ThreadLocalInteger extends ThreadLocal<Integer> {
+        protected Integer initialValue() {
+            return 0;
+        }
+    };
+    private final ThreadLocalInteger recursionDepthPerThread;
+
+    public RecursionSafeAsyncCaller(ExecutorService executorService, AsyncCaller caller, long maxRecursionDepth) {
+        this.executorService = executorService;
+        this.caller = caller;
+        this.maxRecursionDepth = maxRecursionDepth;
+        this.recursionDepthPerThread = new ThreadLocalInteger();
+    }
+
+    public RecursionSafeAsyncCaller(ExecutorService executorService, AsyncCaller caller) {
+        this(executorService, caller, 100);
+    }
+
+    @Override
+    public <T> void resolve(final FutureDone<T> handle, final T result) {
+        execute(() -> caller.resolve(handle, result));
+    }
+
+    @Override
+    public <T> void fail(final FutureDone<T> handle, final Throwable error) {
+        execute(() -> caller.fail(handle, error));
+    }
+
+    @Override
+    public <T> void cancel(final FutureDone<T> handle) {
+        execute(() -> caller.cancel(handle));
+    }
+
+    @Override
+    public void cancel(final FutureCancelled cancelled) {
+        execute(() -> caller.cancel(cancelled));
+    }
+
+    @Override
+    public void finish(final FutureFinished finishable) {
+        execute(() -> caller.finish(finishable));
+    }
+
+    @Override
+    public <T> void resolve(final FutureResolved<T> resolved, final T value) {
+        execute(() -> caller.resolve(resolved, value));
+    }
+
+    @Override
+    public <T, R> void resolve(final StreamCollector<T, R> collector, final T result) {
+        execute(() -> caller.resolve(collector, result));
+    }
+
+    @Override
+    public <T, R> void fail(final StreamCollector<T, R> collector, final Throwable error) {
+        execute(() -> caller.fail(collector, error));
+    }
+
+    @Override
+    public <T, R> void cancel(final StreamCollector<T, R> collector) {
+        execute(() -> caller.cancel(collector));
+    }
+
+    @Override
+    public void fail(final FutureFailed failed, final Throwable cause) {
+        execute(() -> caller.fail(failed, cause));
+    }
+
+    @Override
+    public <T> void referenceLeaked(final T reference, final StackTraceElement[] stack) {
+        execute(() -> caller.referenceLeaked(reference, stack));
+    }
+
+    @Override
+    public void execute(final Runnable runnable) {
+        // Use thread local counter for recursionDepth
+        final Integer recursionDepth = recursionDepthPerThread.get();
+        // ++
+        recursionDepthPerThread.set(recursionDepth + 1);
+
+        if (recursionDepth + 1 <= maxRecursionDepth) {
+            // Case A: Call immediately, this is default until we've reached deep recursion
+            runnable.run();
+        } else {
+            /*
+             * Case B: Defer to a separate thread
+             * This happens when recursion depth of the current thread is larger than limit, to
+             * avoid stack overflow.
+             */
+            executorService.submit(runnable);
+        }
+
+        // --
+        recursionDepthPerThread.set(recursionDepth);
+    }
+
+
+    @Override
+    public boolean isThreaded() {
+        return caller.isThreaded();
+    }
+}

--- a/tiny-async-core/src/test/java/eu/toolchain/async/RecursionSafeAsyncCallerTest.java
+++ b/tiny-async-core/src/test/java/eu/toolchain/async/RecursionSafeAsyncCallerTest.java
@@ -1,0 +1,140 @@
+package eu.toolchain.async;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RecursionSafeAsyncCallerTest {
+    private final Object result = new Object();
+    private final Throwable cause = new Exception();
+
+    private AsyncCaller caller;
+
+    private RecursionSafeAsyncCaller underTest;
+
+    @Mock
+    private FutureDone<Object> done;
+    @Mock
+    private FutureCancelled cancelled;
+    @Mock
+    private FutureFinished finished;
+    @Mock
+    private FutureResolved<Object> resolved;
+    @Mock
+    private FutureFailed failed;
+
+    @Mock
+    private StreamCollector<Object, Object> streamCollector;
+
+    private StackTraceElement[] stack = new StackTraceElement[0];
+
+
+    @Before
+    public void setup() {
+        ExecutorService executor = mock(ExecutorService.class);
+
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                final Runnable runnable = (Runnable) invocation.getArguments()[0];
+                runnable.run();
+                return null;
+            }
+        }).when(executor).submit(any(Runnable.class));
+
+        caller = mock(AsyncCaller.class);
+        underTest = new RecursionSafeAsyncCaller(executor, caller);
+    }
+
+    @Test
+    public void testIsThreaded() {
+        underTest.isThreaded();
+        verify(caller).isThreaded();
+    }
+
+    @Test
+    public void testResolveFutureDone() {
+        underTest.resolve(done, result);
+        verify(caller).resolve(done, result);
+    }
+
+    @Test
+    public void testFailFutureDone() {
+        underTest.fail(done, cause);
+        verify(caller).fail(done, cause);
+    }
+
+    @Test
+    public void testCancelFutureDone() {
+        underTest.cancel(done);
+        verify(caller).cancel(done);
+    }
+
+    @Test
+    public void testRunFutureCancelled() {
+        underTest.cancel(cancelled);
+        verify(caller).cancel(cancelled);
+    }
+
+    @Test
+    public void testRunFutureFinished() {
+        underTest.finish(finished);
+        verify(caller).finish(finished);
+    }
+
+    @Test
+    public void testRunFutureResolved() {
+        underTest.resolve(resolved, result);
+        verify(caller).resolve(resolved, result);
+    }
+
+    @Test
+    public void testRunFutureFailed() {
+        underTest.fail(failed, cause);
+        verify(caller).fail(failed, cause);
+    }
+
+    @Test
+    public void testResolveStreamCollector() {
+        underTest.resolve(streamCollector, result);
+        verify(caller).resolve(streamCollector, result);
+    }
+
+    @Test
+    public void testFailStreamCollector() {
+        underTest.fail(streamCollector, cause);
+        verify(caller).fail(streamCollector, cause);
+    }
+
+    @Test
+    public void testCancelStreamCollector() {
+        underTest.cancel(streamCollector);
+        verify(caller).cancel(streamCollector);
+    }
+
+    @Test
+    public void testLeakedManagedReference() {
+        underTest.referenceLeaked(result, stack);
+        verify(caller).referenceLeaked(result, stack);
+    }
+
+    @Test
+    public void testExecute() {
+        Runnable runnable = mock(Runnable.class);
+        underTest.execute(runnable);
+        verify(runnable).run();
+    }
+}


### PR DESCRIPTION
RecursionSafeAsyncCaller will try to run the call in the current thread as much as possible, while keeping track of recursion to avoid StackOverflowException in the thread. If recursion becomes too deep, the next call is deferred to a separate thread (normal thread pool). State is kept per-thread - stack overflow will be avoided for any thread that passes this code. It is vital to choose a suitable maximum recursion depth.

I should have split out the comment commit to a separate pull request I guess. Will do that next time.