### PR TITLE
[api, core] Expand RetryResult regarding retry timings

### DIFF
--- a/tiny-async-api/src/main/java/eu/toolchain/async/RetryException.java
+++ b/tiny-async-api/src/main/java/eu/toolchain/async/RetryException.java
@@ -1,5 +1,8 @@
 package eu.toolchain.async;
 
+/**
+ * Contains information about a retry that happened while trying to perform an operation
+ */
 public class RetryException extends RuntimeException {
     private final long offset;
 
@@ -8,6 +11,12 @@ public class RetryException extends RuntimeException {
         this.offset = offset;
     }
 
+    /**
+     * Returns timing information for the retry. The value is an offset from a specific point in
+     * time, usually from the beginning of the whole operation.
+     *
+     * @return Timing offset, in milliseconds
+     */
     public long getOffsetMillis() {
         return offset;
     }

--- a/tiny-async-api/src/main/java/eu/toolchain/async/RetryResult.java
+++ b/tiny-async-api/src/main/java/eu/toolchain/async/RetryResult.java
@@ -13,17 +13,43 @@ import java.util.List;
 public class RetryResult<T> {
     final T result;
     final List<RetryException> errors;
+    final List<Long> backoffTimings;
 
-    public RetryResult(final T result, final List<RetryException> errors) {
+    public RetryResult(
+        final T result, final List<RetryException> errors, final List<Long> backoffTimings
+    ) {
         this.result = result;
         this.errors = errors;
+        this.backoffTimings = backoffTimings;
     }
 
     public T getResult() {
         return result;
     }
 
+    /**
+     * Returns information about the retries that happened prior to fulfilling this request.
+     * <p>
+     * Note that the timing 'offset' in each RetryException is the number of milliseconds since one
+     * common point in time, the start of the whole operation.
+     *
+     * @return A list of RetryException's, where each one represents a failed try
+     */
     public List<RetryException> getErrors() {
         return errors;
+    }
+
+    /**
+     * Returns information about the retry backoff pauses that happened between retries (see {@link
+     * #getErrors()}). Each failed retry is followed by a pause before trying another node, to avoid
+     * hammering nodes in the case of an issue in the cluster.
+     * <p>
+     * Note that every timing in the list is the number of microseconds since one common point in
+     * time, the start of the whole operation.
+     *
+     * @return A list of timings, in milliseconds
+     */
+    public List<Long> getBackoffTimings() {
+        return backoffTimings;
     }
 }

--- a/tiny-async-core/src/main/java/eu/toolchain/async/TinyAsync.java
+++ b/tiny-async-core/src/main/java/eu/toolchain/async/TinyAsync.java
@@ -15,7 +15,6 @@ import eu.toolchain.async.helper.RetryCallHelper;
 import eu.toolchain.async.immediate.ImmediateCancelledAsyncFuture;
 import eu.toolchain.async.immediate.ImmediateFailedAsyncFuture;
 import eu.toolchain.async.immediate.ImmediateResolvedAsyncFuture;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -534,6 +533,7 @@ public class TinyAsync implements AsyncFramework {
         future.onFinished(helper::finished);
 
         helper.next();
-        return future.directTransform(result -> new RetryResult<>(result, helper.getErrors()));
+        return future.directTransform(
+            result -> new RetryResult<>(result, helper.getErrors(), helper.getBackoffTimings()));
     }
 }


### PR DESCRIPTION
Store a list of timings (time offsets, like the 'errors' list) for the retry backoff sleeps that happen between retries.