### PR TITLE
Trying to use a non-valid managed ref is an error

### DIFF
--- a/tiny-async-core/src/main/java/eu/toolchain/async/concurrent/ConcurrentManaged.java
+++ b/tiny-async-core/src/main/java/eu/toolchain/async/concurrent/ConcurrentManaged.java
@@ -115,7 +115,7 @@ public class ConcurrentManaged<T> implements Managed<T> {
         final Borrowed<T> b = borrow();
 
         if (!b.isValid()) {
-            return async.cancelled();
+            throw new IllegalStateException("Managed reference is not valid");
         }
 
         final T reference = b.get();

--- a/tiny-async-core/src/test/java/eu/toolchain/async/concurrent/ConcurrentManagedTest.java
+++ b/tiny-async-core/src/test/java/eu/toolchain/async/concurrent/ConcurrentManagedTest.java
@@ -161,7 +161,7 @@ public class ConcurrentManagedTest {
     private void verifyDoto(boolean valid, boolean throwing) throws Exception {
         verify(underTest).borrow();
         verify(borrowed).isValid();
-        verify(async, times(!valid ? 1 : 0)).cancelled();
+        verify(async, times(0)).cancelled();
         verify(async, times(throwing ? 1 : 0)).failed(e);
         verify(borrowed, times(valid ? 1 : 0)).get();
         verify(borrowed, times(valid && !throwing ? 1 : 0)).releasing();
@@ -173,7 +173,13 @@ public class ConcurrentManagedTest {
     @Test
     public void testDotoInvalid() throws Exception {
         setupDoto(false, false);
-        assertEquals(future, underTest.doto(action));
+        boolean didThrow = false;
+        try {
+            underTest.doto(action);
+        } catch (IllegalStateException e) {
+            didThrow = true;
+        }
+        assertEquals("Invalid reference results in exception", true, didThrow);
         verifyDoto(false, false);
     }
 


### PR DESCRIPTION
It previously resulted in a cancellation. Now it's an exception.